### PR TITLE
Fix wrong url selection for t210 boards

### DIFF
--- a/scripts/getKernelSources.sh
+++ b/scripts/getKernelSources.sh
@@ -64,7 +64,7 @@ case ${BOARD_ID} in
      SOURCE_URL=${source_url_list_186[$JETSON_L4T]}
    ;;
    "t210ref" ) 
-     SOURCE_URL=${source_url_list_186[$JETSON_L4T]}
+     SOURCE_URL=${source_url_list_210[$JETSON_L4T]}
    ;;
    *)
     echo "Unrecognized board id: '$BOARD_ID'"


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #14

**Description**
<!-- Add your description below. -->
Before this PR, `getKernelSources.sh` script selects `t186` url for `t210` boards.
After this PR, `getKernelSources.sh` script selects the right `download url` for `t210` boards as expected.

**Checklist:**
- [x] My pull request targets the `master` branch of the repository.
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
