### PR TITLE
Added support for Jetson Orin Nano with JETSON_L4T=35.4.1 and JETSON_JETPACK=5.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Over the years, we have been maintaining several different repositories here and
 * Jetson TX2
 * Jetson AGX Xavier
 * Jetson Xavier NX
+* Jetson Orin Nano
+* Jetson Orin NX
 
 The main difficulty of this approach is that there are several different repositories to maintain across NVIDIA L4T releases.
 

--- a/scripts/getKernelSources.sh
+++ b/scripts/getKernelSources.sh
@@ -20,7 +20,7 @@ declare -A source_url_list_210=(
 # Table of the URLs to Kernel Sources for Jetson TX2, AGX Xavier, Xavier NX, AGX Orin
 # L4T Driver Package [BSP] Sources - Code 186
 declare -A source_url_list_186=( 
-  ["35.1.0"]="https://developer.nvidia.com/embedded/l4t/r35_release_v1.0/sources/public_sources.tbz2"
+  ["35.4.1"]="https://developer.nvidia.com/embedded/l4t/r35_release_v4.1/sources/public_sources.tbz2"
   ["32.7.3"]="https://developer.nvidia.com/downloads/remack-sdksjetpack-463r32releasev73sourcest186publicsourcestbz2"
   ["32.7.2"]="https://developer.nvidia.com/embedded/l4t/r32_release_v7.2/sources/t186/public_sources.tbz2"
   ["32.7.1"]="https://developer.nvidia.com/embedded/l4t/r32_release_v7.1/sources/t186/public_sources.tbz2"
@@ -78,7 +78,7 @@ case ${BOARD_ID} in
     exit 1
 esac
 
-if [ $SOURCE_URL = "" ] ; then
+if [ "$SOURCE_URL" = "" ] ; then
   echo "Unable to find source files on developer.nvidia.com"
   echo "L4T $JETSON_L4T"
   exit 1

--- a/scripts/jetson_variables
+++ b/scripts/jetson_variables
@@ -30,6 +30,7 @@ jetson_jetpack()
     local JETSON_L4T=$1
     local JETSON_JETPACK=""
     case $JETSON_L4T in
+        "35.4.1") JETSON_JETPACK="5.1.2" ;;
         "35.1.0") JETSON_JETPACK="5.0.2" ;;
         "34.1.1") JETSON_JETPACK="5.0.1 DP" ;;
         "34.1.0") JETSON_JETPACK="5.0 DP" ;;


### PR DESCRIPTION
**Description**
- Added support for Jetson Orin Nano with JETSON_L4T=35.4.1 and JETSON_JETPACK=5.1.2. 
- Fixed a bug in scripts/getKernelSources.sh:81 which was unable to recognize and throw error if  SOURCE_URL is empty.
- Updated readme.md and added Jetson Orin NX and Jetson Orin Nano in supported devices.

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
